### PR TITLE
redirection after play, dnf no longer restricted to a week

### DIFF
--- a/src/InputForm.jsx
+++ b/src/InputForm.jsx
@@ -622,7 +622,10 @@ Wordle 1,234 4/6
                 </p>
                 <br />
                 <button
-                  onClick={() => window.open('https://www.nytimes.com/games/wordle', '_blank', 'noopener,noreferrer')}
+                  onClick={() => {
+                    window.open('https://www.nytimes.com/games/wordle', '_blank', 'noopener,noreferrer');
+                    setActiveTab('Score Entry');
+                  }}
                   className={classes.playButtonStyle}
                   style={{
                     background: getCurrentGradient ? getCurrentGradient() : "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"

--- a/src/Leaderboard.jsx
+++ b/src/Leaderboard.jsx
@@ -568,8 +568,8 @@ const Leaderboard = ({ getCurrentGradient }) => {
           };
         }).sort((a, b) => b.attempts - a.attempts);
 
-        // Wooden spoon leaderboard (most DNFs this week)
-        const woodspoonData = weeklyScores.reduce((acc, score) => {
+        // Wooden spoon leaderboard (most DNFs all time)
+        const woodspoonData = allTimeScores.reduce((acc, score) => {
           if (!acc[score.name]) {
             acc[score.name] = { totalDNFs: 0, attempts: 0 };
           }
@@ -585,10 +585,11 @@ const Leaderboard = ({ getCurrentGradient }) => {
           .map(name => ({
             name,
             totalDNFs: woodspoonData[name].totalDNFs,
-            attempts: woodspoonData[name].attempts
+            attempts: woodspoonData[name].attempts,
+            percentage: (woodspoonData[name].totalDNFs / woodspoonData[name].attempts) * 100
           }))
           .filter(entry => entry.totalDNFs > 0)
-          .sort((a, b) => b.totalDNFs - a.totalDNFs);
+          .sort((a, b) => b.percentage - a.percentage);
 
         setDailyLeaderboard(dailyLeaderboardArray);
         setWeeklyLeaderboard(weeklyLeaderboardArray);
@@ -859,14 +860,14 @@ const Leaderboard = ({ getCurrentGradient }) => {
                 <div className={classes.cardHeader}>
                   <h2 className={classes.cardTitle}>
                     🥄 Wooden Spoon
-                    <span title="Shows players with the most DNFs (Did Not Finish, scored as 7) this week. Only games from the 5 most recent weekdays are counted.">
+                    <span title="Shows players with the most DNFs (Did Not Finish, scored as 7) of all time. All games ever played are counted.">
                       🛈
                     </span>
                   </h2>
-                  <p className={classes.cardSubtitle}>Most DNFs this week</p>
+                  <p className={classes.cardSubtitle}>Most DNFs all time</p>
                 </div>
                 <ul className={classes.leaderboardList}>
-                  {woodspoonLeaderboard.slice(0, 5).map((entry, index) => (
+                  {woodspoonLeaderboard.slice(0, 20).map((entry, index) => (
                     <li key={index} className={classes.leaderboardItem}>
                       <div className={classes.rank}>
                         🥄


### PR DESCRIPTION
This pull request updates the "Wooden Spoon" leaderboard to show all-time DNFs (Did Not Finish) instead of just weekly DNFs, and improves how the leaderboard is sorted and displayed. It also makes a small UI improvement to the "Play Wordle" button.

**Leaderboard improvements:**

* The "Wooden Spoon" leaderboard now calculates DNFs using all historical scores instead of just the past week, providing a more comprehensive view of player performance.
* Leaderboard entries now include a percentage of DNFs per attempts, and the leaderboard is sorted by this percentage rather than just the total DNFs, making it more fair for players with different numbers of games played.
* The UI has been updated to reflect these changes: the tooltip and subtitle now clarify that the leaderboard shows all-time DNFs, and the displayed list has been expanded from the top 5 to the top 20 players for increased visibility.

**UI improvement:**

* The "Play Wordle" button now also switches the active tab to "Score Entry" after opening the Wordle game, streamlining the user experience.